### PR TITLE
small typo in directories name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Please go to the directory exercise\_3.
 
 To find **characters seven and eight**, you need to create a
 subdirectory named *solution* in `exercise_3/` and copy the files from
-the `code1/` and `code2/` folders into it.
+the `part1/` and `part2/` folders into it.
 
 For creating directories, use the command:
 


### PR DESCRIPTION
When you clone the repository the directory names in the third section are `part1` and `part2`.