### PR TITLE
Missing argument to perform a non-casesensitive sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ To store the sorted lines in a new file, you can add an output file,
 like
 
 ``` {.sourceCode .bash}
-less <filename> | sort > result.txt
+less <filename> | sort -f > result.txt
 ```
 
 </div>


### PR DESCRIPTION
Hello, 
we discovered that in 4.2 exercise the proposed resolution is sorting without differentiating uppercase/lowercase characters. Thus, the command is not sorting correctly the text inside elephant.txt file. 